### PR TITLE
Auto configuration scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ OpenSSL OK
 kmod OK
 Util-Linux OK
 e2fsprogs OK
- 
+
 ### If everything is OK above you should be able to compile
- 
+
 jfsutils NO
 reiserfsprogs NO
 squashfs-tools NO
@@ -52,11 +52,11 @@ Git OK
 GCC is a compiler for C and C++ programming languages, the Linux Kernel is written in C and GCC is it's default compiler
 
 ### Clang [Wikipedia](https://en.wikipedia.org/wiki/Clang)
-Clang is an "LLVM native" C/C++/Objective-C compiler a substitute to GCC. Distributions such as Android, ChromeOS use Clang built kernels. 
+Clang is an "LLVM native" C/C++/Objective-C compiler a substitute to GCC. Distributions such as Android, ChromeOS use Clang built kernels.
 :smile:  Pronounced “klang,” not “see-lang.”
 
 ### Make [Read more](https://www.gnu.org/software/make/)
-Make is a tool which controls the generation of executables and other non-source files of a program from the program's source files. 
+Make is a tool which controls the generation of executables and other non-source files of a program from the program's source files.
 
 ### Binutils [Read more](https://www.gnu.org/software/binutils/)
 Binutils is a collection of software development tools containing a linker, assembler and other tools to work with object files and archives.
@@ -74,19 +74,18 @@ Might wonder why perl? Obviously the Linux Kernel isn't written in Perl but it i
 bc is used during the kernel build to generate time constants in header files. Perl was formerly used but required a mechanism to support Perl < 5.8 installations lacking the ``Math::BigInt`` module [check this commit](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=70730bca1331fc50c3caacaea00439de1325bd6e). Though this could still be implemented with C or Perl.
 
 ### OpenSSL [Wikipedia](https://en.wikipedia.org/wiki/OpenSSL)
-Module signing and external certificate handling use the OpenSSL and crypto library to do key creation and signature generation. 
+Module signing and external certificate handling use the OpenSSL and crypto library to do key creation and signature generation.
 
 ### Kmod [Read more](https://man7.org/linux/man-pages/man8/kmod.8.html)
 kmod is a multi-call binary which implements the programs used to control Linux Kernel modules. Linux distributions use modules in order to load only the needed driver for the system based on the hardware present, instead of building all possible drivers in the kernel to one large chunk.
 
 **These are the basic packages required listed, you can find others [here](https://www.kernel.org/doc/html/latest/process/changes.html)**
 
-
+## git_setup.sh & mutt_setup.sh scripts
+[Read More about mutt](http://www.mutt.org/doc/manual/#configuration)
+[Read More about git](https://git-scm.com/docs/git-send-email)
+Both scripts help with the configuration of email.<br>
+Usage: ``bash mutt_setup.sh``
 
 ## Found this useful?
 Star the repo and follow me on [Twitter](https://twitter.com/nwebedu_junior) Thanks :heart:
-
-
-
-
-

--- a/conf_email/git_setup.sh
+++ b/conf_email/git_setup.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+ORANGE="$(printf '\033[33m')" RESETBG="$(printf '\e[0m\n')"
+
+read -p "Enter full name: " name
+read -p "Enter email: " email
+read -p "Enter SMTP server: " smtp
+read -p "Enter your password ${ORANGE}[*security risk*]: ${RESETBG}" password
+echo "$name,$email,$smtp,$password"
+
+git config --global user.name "$name"
+git config --global user.email "$email"
+git config --global sendmail.smtpencryption tls
+git config --global sendmail.smtpserver "$smtp"
+git config --global sendmail.smtpuser "$email"
+git config --global sendmail.serverport 587
+git config --global sendmail.smtppass "$password"
+
+echo
+echo "Content of ~/.gitconfig file"
+cat ~/.gitconfig

--- a/conf_email/mutt_setup.sh
+++ b/conf_email/mutt_setup.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+
+## ANSI colors (FG & BG)
+RED="$(printf '\033[31m')"  GREENS="$(printf '\033[32m')"  ORANGE="$(printf '\033[33m')"  BLUE="$(printf '\033[34m')"
+MAGENTA="$(printf '\033[35m')"  CYAN="$(printf '\033[36m')"  WHITE="$(printf '\033[37m')" BLACK="$(printf '\033[30m')"
+REDBG="$(printf '\033[41m')"  GREENBG="$(printf '\033[42m')"  ORANGEBG="$(printf '\033[43m')"  BLUEBG="$(printf '\033[44m')"
+MAGENTABG="$(printf '\033[45m')"  CYANBG="$(printf '\033[46m')"  WHITEBG="$(printf '\033[47m')" BLACKBG="$(printf '\033[40m')"
+RESETBG="$(printf '\e[0m\n')"
+
+## Script termination
+exit_on_signal_SIGINT() {
+    { printf "\n\n%s\n\n" "${RED}[${WHITE}!${RED}]${RED} Program Interrupted." 2>&1; reset_color; }
+    exit 0
+}
+
+exit_on_signal_SIGTERM() {
+    { printf "\n\n%s\n\n" "${RED}[${WHITE}!${RED}]${RED} Program Terminated." 2>&1; reset_color; }
+    exit 0
+}
+
+trap exit_on_signal_SIGINT SIGINT
+trap exit_on_signal_SIGTERM SIGTERM
+
+## Reset terminal colors
+reset_color() {
+	tput sgr0   # reset attributes
+	tput op     # reset color
+    return
+}
+
+function check() {
+# checks if your distribution is ready for kernel development.
+
+if [[ `command -v mutt` ]]; then
+  echo "mutt OK"
+  echo ""
+else
+  echo "mutt ${RED}NO${RESETBG}"
+  install
+fi
+}
+
+function install {
+echo
+read -p "install packages not found?[y/n] "
+if [[ "$REPLY" == y || "$REPLY" == yes ]] && [[ `command -v apt-get` ]]; then
+	echo -e "\n${GREEN}[${WHITE}+${GREENS}]${GREENS} Apt package manager detected installing packages........."
+	sleep 1
+	sudo apt-get update && sudo apt-get install mutt && echo ${RED} "Packages installed!!!"
+elif [[ "$REPLY" == y || "$REPLY" == yes ]] && [[ `command -v yum` ]]; then
+	echo -e "\n${GREEN}[${WHITE}+${GREENS}]${GREENS} Yum package manager detected installing packages........."
+	sleep 1
+	sudo sudo yum groupinstall "Development Tools" && sudo yum update && sudo yum install mutt && echo ${RED} "Packages installed!!!"
+elif [[ "$REPLY" == y || "$REPLY" == yes ]] && [[ `command -v dnf` ]]; then
+	echo -e "\n${GREEN}[${WHITE}+${GREENS}]${GREENS} Dnf package manager detected installing packages........."
+	sleep 1
+	sudo dnf group install "Development Tools" && sudo dnf install mutt && echo ${RED} "Packages installed!!!"
+else echo -ne "${RESETBG}\n${WHITEBG}${BLACK}[${BLACK}!${BLACK}]${BLACK} Thanks for using this tool have a good day and spread the love 💖 ${RESETBG}\n" && exit
+fi
+echo
+}
+
+function setup {
+  # create folders & files
+  if [[ ! -d "~/.mutt/cache/headers" ]]; then
+    mkdir -p ~/.mutt/cache/headers
+  fi
+
+  if [[ ! -d "~/.mutt/cache/bodies" ]]; then
+    mkdir -p ~/.mutt/cache/bodies
+  fi
+
+  if [[ ! -f "~/.mutt/certificates" ]]; then
+    touch ~/.mutt/certificates
+  fi
+
+  if [[ ! -f "~/.muttrc" ]]; then
+    touch ~/.muttrc
+  fi
+
+  # Info & configuration
+  read -p "Enter your email: " imap_user
+  username=${imap_user%@*} #  keep only the username
+
+  read -p "Enter your password: " imap_pass
+
+  # Auto configuration
+  read -p "Enter email provider [ gmail / outlook / manual ]: "
+  if [[ "$REPLY" == 'gmail' ]]; then
+    # ================  IMAP ====================
+    spoolfile="imaps://imap.gmail.com/INBOX"
+    folder="imaps://imap.gmail.com/"
+    record="imaps://imap.gmail.com/[Gmail]/Sent Mail"
+    postponed="imaps://imap.gmail.com/[Gmail]/Drafts"
+    mbox="imaps://imap.gmail.com/[Gmail]/All Mail"
+
+    # ================  SMTP  ====================
+    smtp_url="smtp://$username@smtp.gmail.com:587/"
+    smtp_pass=${imap_pass}
+    ssl_force_tls='yes' # Require encrypted connection
+  elif [[ "$REPLY" == 'outlook' ]]; then
+    echo "Sorry! Outlook auto-configuration is not available yet..."
+    exit
+  elif [[ "$REPLY" == 'manual' ]]; then
+    read -p "Enter spoolfile: " spoolfile
+    read -p "Enter folder: " folder
+    read -p "Enter record: " record
+    read -p "Enter postponed: " postponed
+    read -p "Enter mbox: " mbox
+    read -p "Enter smtp url: " smtp_url
+    smtp_pass=${imap_pass}
+    ssl_force_tls='yes'
+  fi
+
+  # ================  Composition  ====================
+  read -p "Enter editor [vim]: " editor
+  editor=${editor:-'vim'}
+  edit_headers="yes"
+  charset="UTF-8"
+  read -p "Enter your name: " realname
+  from=$imap_user # *** I AM NOT SURE ABOUT THIS ***
+  use_from='yes'
+
+  # Text for .muttrc file
+  text=(
+    "# .muttrc"
+    "# ================  IMAP ===================="
+    "set imap_user = '$imap_user'"
+    "set imap_pass = '$imap_pass'"
+    "set spoolfile = $spoolfile"
+    "set folder = $folder"
+    "set record=\"$record\""
+    "set postponed=\"$postponed\""
+    "set mbox =\"$mbox\""
+    ""
+    "# ================  SMTP  ===================="
+    "set smtp_url = \"$smtp_url\""
+    "set smtp_pass = '$imap_pass'"
+    "set ssl_force_tls = $ssl_force_tls # Require encrypted connection"
+    ""
+    "# ================  Composition  ===================="
+    "set editor = $editor"
+    "set edit_headers = $edit_headers  # See the headers when editing"
+    "set charset = $charset     # value of $LANG; also fallback for send_charset"
+    "# Sender, email address, and sign-off line must match"
+    "unset use_domain        # because joe@localhost is just embarrassing"
+    "set realname = \"$realname\""
+    "set from = \"$from\""
+    "set use_from = $use_from"
+    )
+    printf '%s\n' "${text[@]}" > ~/.muttrc
+    printf "~/.muttrc file is ready"
+    echo -ne "${RESETBG}\n${WHITEBG}${BLACK}[${BLACK}!${BLACK}]${BLACK} Thanks for using this tool have a good day and spread the love 💖 ${RESETBG}\n"
+}
+
+check
+setup


### PR DESCRIPTION
I added mutt_setup.sh script. It is responsible to check if mutt is installed in the system and help the user with the setup. 

I tried to keep the logic and style of code same with the check.sh file. A small change is that I call _install_ function (previous main) through _check_ function only if mutt package is **NOT** installed.

Also at line 88 - 113 I tried to help the users based on their choices. If they want to use outlook, gmail or to configure everything manually. Gmail is ready but outlook is not. 
- [ ]  add yahoo option
- [ ]  complete outlook option

Lastly, I think it's better to keep both git_setup.sh and mutt_setup.sh and provide both options for Linux kernel developers.

IMPORTANT: Gmail blocks any login attempt for 'untrusted' apps. Visit [this](https://unix.stackexchange.com/questions/172666/gmail-blocking-mutt/239548#239548) to overcome the issue. 

As always feel free to change whatever you want before merging. Hope that you like it! 